### PR TITLE
Feat: 컬럼카드에 유저 프로필이미지 표시로 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,26 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- SEO 메타 태그 -->
+    <meta name="description" content="Taskify는 일의 우선순위를 정해 효율적으로 관리할 수 있도록 도와주는 일정 관리 서비스 입니다." />
+    <meta name="keywords" content="Taskify, 작업 관리, 일정, 할 일 목록, 생산성 도구" />
+    <meta name="author" content="codeit-5-8" />
+
+    <!-- Open Graph 메타 태그 (소셜 미디어) -->
+    <meta property="og:title" content="Taskify" />
+    <meta property="og:description" content="Taskify는 일의 우선순위를 정해 효율적으로 관리할 수 있도록 도와주는 일정 관리 서비스 입니다." />
+    <meta property="og:image" content="https://i.ibb.co/dQp7gY8/desktop.png" />
+    <!-- <meta property="og:url" content="배포 시 변경" /> -->
+    <meta property="og:type" content="website" />
+
+    <!-- Twitter 메타 태그 -->
+    <meta name="twitter:card" content="https://i.ibb.co/dQp7gY8/desktop.png" />
+    <meta name="twitter:title" content="Taskify" />
+    <meta name="twitter:description" content="Taskify는 일의 우선순위를 정해 효율적으로 관리할 수 있도록 도와주는 일정 관리 서비스 입니다." />
+    <meta name="twitter:image" content="https://yourdomain.com/path/to/image.jpg" />
+
+    <!-- Google Fonts 및 Pretendard 폰트 -->
     <link
       rel="stylesheet"
       as="style"
@@ -16,6 +36,7 @@
       href="https://fonts.googleapis.com/css2?family=Abel&family=Acme&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Noto+Sans+KR:wght@100..900&display=swap"
       rel="stylesheet"
     />
+
     <title>Taskify</title>
   </head>
   <body>

--- a/src/pages/dashboard.{dashboardid}/components/ColumnCard/ColumnCard.tsx
+++ b/src/pages/dashboard.{dashboardid}/components/ColumnCard/ColumnCard.tsx
@@ -4,6 +4,7 @@ import styles from './ColumnCard.module.scss';
 import Tag from '../../../../components/chip/Tag/Tag';
 import TodoCardManagement from '../../../modal/TodoCardManagement/TodoCardManagement';
 import { CardOverAll } from '../../../../api/apiModule';
+import { UserProfileImgSvg } from '../../../../components/UserProfileImg/UserProfileImg';
 
 interface CardProps {
   cardId: number;
@@ -23,12 +24,7 @@ const formatDate = (date: string) => {
 
 // 일정을 카드 모양으로 보여주는 컴포넌트입니다.
 // 사진, 제목, 태그, 기한, 작성자이미지를 prop으로 받습니다.
-// 현재 작성자 이미지 대신 이름만 보여지게 처리했습니다. 수정 필요합니다.
-function ColumnCard({
-  cardId,
-  cardData,
-  columnData,
-}: CardProps) {
+function ColumnCard({ cardId, cardData, columnData }: CardProps) {
   const [manageCardModalOpen, setManageCardModalOpen] = useState<boolean>(false);
   const {
     assignee,
@@ -37,7 +33,6 @@ function ColumnCard({
     tags,
     imageUrl,
   } = cardData;
-
   // 버튼 이벤트 핸들러
   const cardOnClick = () => {
     setManageCardModalOpen(true);
@@ -71,7 +66,13 @@ function ColumnCard({
             <img src="/icon/calendar.svg" alt="calendarImg" />
             {formatDate(dueDate)}
           </div>
-          <div className={styles.avatar}>{assignee.nickname}</div>
+          <div className={styles.avatar}>
+            {assignee.profileImageUrl ? (
+              <UserProfileImgSvg profileImageUrl={assignee.profileImageUrl} />
+            ) : (
+              assignee.nickname
+            )}
+          </div>
         </div>
       </button>
 


### PR DESCRIPTION
이미지 없을 시 기존처럼 닉네임이 표시되게 예외처리했습니다.
테스트는 아직 못해봤습니다.. 유저 프로필이미지가 있는 계정을 못만들고있어요


+ 대시보드페이지 가로스크롤 보이게 해보려했는데 scss를 아무리 건드려봐도 스크롤이 컬럼에 생기는 바람에 수정하지 못했습니다. 컬럼 목록을 담당하는 부분에 스크롤이 생기는게 아니라 컬럼 하나하나마다 쓸모없는 스크롤이 생겨요.
컴포넌트를 분리해보기도하고, 아예 스크롤바 모양 컴포넌트를 만드려해도 실패했습니다...
쉬프트+휠을 하면 옆으로 가지긴 합니다.

Index.html
SEO, OG관련 메타 태그 추가했습니다.