### PR TITLE
feat: 회원가입 시 기본 이미지 업로드 기능 추가

### DIFF
--- a/src/api/users/apiUsers.tsx
+++ b/src/api/users/apiUsers.tsx
@@ -52,6 +52,7 @@ export async function apiUploadImage(
   const res = await instance.post<EditImageResponse>('/users/me/image', body, {
     headers: {
       'Content-Type': 'multipart/form-data',
+      Authorization: `Bearer ${localStorage.getItem('Token')}`, // 토큰 설정 추가
     },
   });
   return handleResponse(res);

--- a/src/pages/login-signup/components/utils/useSignUpForm.ts
+++ b/src/pages/login-signup/components/utils/useSignUpForm.ts
@@ -1,7 +1,11 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { apiSignUp } from '../../../../api/apiModule';
-import defaultProfileImgMaker from '../../../../utils/defaultProfileImgMaker';
+import {
+  apiSignUp,
+  apiLoginRequest,
+  apiUploadImage,
+} from '../../../../api/apiModule';
+import defaultProfileImg from '../../../../../public/img/default.png';
 
 // 회원가입 폼 제출 기능을 수행하는 함수입니다.
 // useNavigate를 사용하여 폼 제출 시 다른 페이지로 이동하도록 구현했습니다.
@@ -29,7 +33,6 @@ function useSignUpForm() {
 
   // 이외의 상태 관리
   const [loading, setLoading] = useState(false);
-  const [, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
   const navigate = useNavigate();
@@ -46,23 +49,40 @@ function useSignUpForm() {
     navigate('/login'); // 회원가입 성공 시 로그인 페이지로 이동
   };
 
+  // 기본 이미지를 Blob으로 변환하는 함수
+  const getDefaultImageBlob = async (): Promise<Blob> => {
+    const response = await fetch(defaultProfileImg);
+    const blob = await response.blob();
+    return blob;
+  };
+
   // 회원가입 폼 제출
   const handleSubmit = async (e: { preventDefault: () => void }) => {
     e.preventDefault();
     setLoading(true); // 회원가입 시도 중에는 버튼 비활성화
-    setError(null);
 
     const { email, nickname, password } = values;
 
     try {
-      await apiSignUp({ email, nickname, password }); // 회원가입 API 호출
+      await apiSignUp({
+        email,
+        nickname,
+        password,
+      }); // 회원가입 API 호출
 
-      defaultProfileImgMaker({ name: nickname }); // 프로필 이미지 생성
+      // 회원가입 후 바로 로그인
+      await apiLoginRequest({ email, password });
+
+      // 기본 이미지를 Blob으로 변환하여 업로드
+      const defaultImageBlob = await getDefaultImageBlob();
+      const formData = new FormData();
+      formData.append('image', defaultImageBlob, 'default.png');
+
+      await apiUploadImage(formData); // 기본 프로필 이미지 업로드
 
       setIsModalOpen(true); // 성공 시 모달 창 띄우기
     } catch (error) {
       setIsErrorModalOpen(true);
-      setError('중복된 이메일입니다.');
     } finally {
       setLoading(false); // 회원가입 시도가 끝나면 버튼 활성화
     }


### PR DESCRIPTION
회원가입 시 유저 데이터에 기본 이미지를 업로드 하도록 했습니다.
추가적으로 회원가입 완료 시 바로 로그인 되도록 했습니다.
회원가입 시 이미지 업로드 함수 사용할 때 401에러가 발생해서 이미지 업로드 api 함수에 토큰을 설정하는 기능을 추가했습니다.