### PR TITLE
style: 카드 프로필이미지 위치 수정

### DIFF
--- a/src/pages/dashboard.{dashboardid}/components/ColumnCard/ColumnCard.module.scss
+++ b/src/pages/dashboard.{dashboardid}/components/ColumnCard/ColumnCard.module.scss
@@ -39,7 +39,7 @@
     height: 5.813rem;
     padding-left: 0;
     grid-template-areas:
-      'img  title title title'
+      'img  title title avatar'
       'img  tag   date  avatar';
     grid-template-columns: auto auto 1fr auto;
     grid-template-rows: auto;
@@ -106,5 +106,8 @@
 
 .avatar {
   grid-area: avatar;
+  display: flex;
+  justify-content: center;
+  align-items: end;
   margin-left: auto;
 }


### PR DESCRIPTION
![image](https://github.com/eunji-0623/Taskify/assets/159979425/80cee534-bd6a-42bf-a107-a466aa1ab8ea)

이미지 대신 닉네임을 임시로 넣고 쓰고있었어서 이미지가 들어갔을 때의 디자인이 약간 안맞았었습니다.
해당 내용 스타일 수정했습니다.